### PR TITLE
fix: parseStatusLine() for multiple words status message

### DIFF
--- a/src/parser.coffee
+++ b/src/parser.coffee
@@ -5,37 +5,37 @@ parseRequest = (requestString) ->
   parsedRequestLine = parseRequestLine lines.shift()
   request['method'] = parsedRequestLine['method']
   request['uri'] = parsedRequestLine['uri']
-  
+
   #TODO refactor this part to be tested
   headerLines = []
   while lines.length > 0
     line = lines.shift()
     break if line == ""
     headerLines.push line
-  
+
   request['headers'] = parseHeaders headerLines
   request['body'] = lines.join '\r\n'
-  
+
   request
 
 parseResponse = (responseString) ->
   response = {}
   lines = responseString.split('\r\n')
-  
+
   parsedStatusLine = parseStatusLine lines.shift()
   response['statusCode'] = parsedStatusLine['statusCode']
   response['statusMessage'] = parsedStatusLine['statusMessage']
-  
+
   #TODO refactor this part to be tested
   headerLines = []
   while lines.length > 0
     line = lines.shift()
     break if line == ""
     headerLines.push line
-  
+
   response['headers'] = parseHeaders headerLines
   response['body'] = lines.join '\r\n'
-  
+
   response
 
 parseHeaders = (headerLines) ->
@@ -48,15 +48,16 @@ parseHeaders = (headerLines) ->
   headers
 
 parseStatusLine = (statusLine) ->
-  parts = statusLine.split ' '
+  parts = statusLine.match /^(.+) ([0-9]{3}) (.*)$/
   parsed = {}
 
-  parsed['protocol'] = parts[0]
-  parsed['statusCode'] = parts[1]
-  parsed['statusMessage'] = parts[2]
+  if parts isnt null
+    parsed['protocol'] = parts[1]
+    parsed['statusCode'] = parts[2]
+    parsed['statusMessage'] = parts[3]
 
   parsed
-  
+
 parseRequestLine = (requestLineString) ->
   parts = requestLineString.split(' ')
   parsed = {}

--- a/src/parser.coffee
+++ b/src/parser.coffee
@@ -23,6 +23,7 @@ parseResponse = (responseString) ->
   lines = responseString.split('\r\n')
 
   parsedStatusLine = parseStatusLine lines.shift()
+  response['protocolVersion'] = parsedStatusLine['protocol']
   response['statusCode'] = parsedStatusLine['statusCode']
   response['statusMessage'] = parsedStatusLine['statusMessage']
 

--- a/test/fixtures/get/response-string-304
+++ b/test/fixtures/get/response-string-304
@@ -1,0 +1,9 @@
+HTTP/1.1 304 Not Modified
+Content-Type: application/json
+Date: Sun, 21 Jul 2013 13:23:55 GMT
+X-Apiary-Ratelimit-Limit: 120
+X-Apiary-Ratelimit-Remaining: 119
+Content-Length: 119
+Connection: keep-alive
+
+{ "message": "hello world" }

--- a/test/integration/curl-trace-parser-test.coffee
+++ b/test/integration/curl-trace-parser-test.coffee
@@ -7,23 +7,23 @@ curl = require 'curl-trace-parser'
 describe "Parse output from curl trace parser", () ->
   traceFilePath = "./test/fixtures/post/tracefile"
   parsedCurlStrings = {}
-  
+
 
   before (done) ->
     fs.readFile traceFilePath, 'utf8', (err, trace) ->
       done err if err
       parsedCurlStrings = curl.parse trace
       done()
-  
+
   describe "request", () ->
     request = {}
-    
+
     before () ->
       request = parser.parseRequest parsedCurlStrings['request']
-    
+
     it "should parse string to expected object", () ->
       expectedObject =
-        headers: 
+        headers:
           'User-Agent': 'curl/7.24.0 (x86_64-apple-darwin12.0) libcurl/7.24.0 OpenSSL/0.9.8x zlib/1.2.5'
           'Host': 'curltraceparser.apiary.io'
           'Accept':'*/*'
@@ -32,20 +32,21 @@ describe "Parse output from curl trace parser", () ->
         body: '{ \"product\":\"1AB23ORM\", \"quantity\": 2 }'
         method: 'POST'
         uri: '/shopping-cart'
-      
-      assert.deepEqual request, expectedObject 
-  
+
+      assert.deepEqual request, expectedObject
+
   describe "response", () ->
     response = {}
-    
+
     before () ->
       response = parser.parseResponse parsedCurlStrings['response']
-    
+
     it "should parse string to expected object", () ->
       expectedObject =
+        protocolVersion: "HTTP/1.1"
         statusCode: "201"
         statusMessage: "Created"
-        headers: 
+        headers:
           'Content-Type': 'application/json'
           'Content-Length': '39'
           'Date': 'Sun, 21 Jul 2013 14:51:09 GMT'
@@ -56,6 +57,3 @@ describe "Parse output from curl trace parser", () ->
         body: '{ "status": "created", "url": "/shopping-cart/2" }'
 
       assert.deepEqual response, expectedObject
-
-
-

--- a/test/unit/parser-test.coffee
+++ b/test/unit/parser-test.coffee
@@ -4,12 +4,12 @@ fs = require 'fs'
 parser = require '../../src/parser'
 
 describe "parser module", () ->
-  
+
   # http://www.w3.org/Protocols/rfc2616/rfc2616-sec4.html#sec4.2
   describe "parseHeaders(headersLines)", () ->
     it "should be a function", () ->
       assert.isFunction parser.parseHeaders
-    
+
     describe "its return", () ->
       output = ""
       headerLines = [
@@ -19,14 +19,14 @@ describe "parser module", () ->
         "Content-Type: application/json",
         "Content-Length: 39",
       ]
-      
+
       before () ->
         output = parser.parseHeaders headerLines
 
       describe "its retrun", () ->
         it "should be object", () ->
           assert.isObject output
-        
+
         ['User-Agent', 'Host', "Accept", "Content-Type", "Content-Length"].forEach (key) ->
           it "should contain key '" + key + "'", () ->
             assert.include Object.keys(output), key
@@ -43,26 +43,26 @@ describe "parser module", () ->
     lineStrings =
       POST: "POST /shopping-cart HTTP/1.1"
       GET:  "GET /shopping-cart HTTP/1.1"
-    
+
     for method, line of lineStrings
       describe "return for " + method + " line", () ->
         output = ""
         before () ->
           output = parser.parseRequestLine line
-        
-        it "should be object", () -> 
+
+        it "should be object", () ->
           assert.isObject output
 
         ['method','uri','protocol'].forEach (key) ->
           it "should contain not empty string on key: " + key, () ->
             assert.isString output[key]
-        
+
         it "should have parsed method " + method, () ->
           assert.equal output['method'], method
 
         it "should have parsed uri " + method, () ->
           assert.equal output['uri'], "/shopping-cart"
-  
+
   # http://www.w3.org/Protocols/rfc2616/rfc2616-sec6.html#sec6.1
   describe "parseStatusLine", () ->
     it "is a function", () ->
@@ -74,22 +74,22 @@ describe "parser module", () ->
 
       before () ->
         output = parser.parseStatusLine statusLine
-        
+
       ['protocol','statusCode','statusMessage'].forEach (key) ->
         it "should contain not empty string on key: " + key, () ->
           assert.isString output[key]
-       
+
         it 'should contain statusCode "201"', () ->
           assert output['statusCode'], "201"
 
         it 'should contain statusMessage "Created"', () ->
           assert output['statusCode'], "Created"
-  
+
   # http://www.w3.org/Protocols/rfc2616/rfc2616-sec5.html
   describe "parseRequest(requestString)", () ->
     requestPath = "/../fixtures/post/request-string"
     requestString = ""
-    
+
     before (done) ->
       #load fixture
       fs.readFile __dirname + requestPath, (err, data) ->
@@ -99,54 +99,54 @@ describe "parser module", () ->
 
     it "is a function", () ->
       assert.isFunction parser.parseRequest
-    
+
     describe 'its return', () ->
       output = ""
-    
+
       before () ->
         output = parser.parseRequest(requestString)
 
       ['method', 'uri', 'headers', 'body'].forEach (key) ->
         it 'should have key "'+ key + '"', () ->
           assert.include Object.keys(output), key
-      
+
       describe "method", () ->
         subject = ""
-        
+
         before () ->
           subject = output['method']
-        
+
         it 'should contain "POST"', () ->
           assert.equal subject, "POST"
 
       describe "uri", () ->
         subject = ""
-        
+
         before () ->
           subject = output['uri']
-        
+
         it 'should contain "/shopping-cart"', () ->
           assert.equal subject, "/shopping-cart"
 
       describe "headers", () ->
         subject = ""
-        
+
         before () ->
           subject = output['headers']
-        
+
         it 'should be object', () ->
           assert.isObject subject
 
-        it 'should have "User-Agent" key', () -> 
+        it 'should have "User-Agent" key', () ->
           assert.include Object.keys(subject), "User-Agent"
-         
+
         it 'should have proper User-Agent value', () ->
           agentString = "curl/7.24.0 (x86_64-apple-darwin12.0) libcurl/7.24.0 OpenSSL/0.9.8x zlib/1.2.5"
           assert.equal agentString, subject['User-Agent']
 
       describe "body", () ->
         subject = ""
-        
+
         before () ->
           subject = output['body']
 
@@ -158,7 +158,7 @@ describe "parser module", () ->
   describe "parseResponse(responseString)", () ->
     responsePath = "/../fixtures/post/response-string"
     responseString = ""
-    
+
     before (done) ->
       #load fixture
       fs.readFile __dirname + responsePath, (err, data) ->
@@ -168,58 +168,126 @@ describe "parser module", () ->
 
     it "is a function", () ->
       assert.isFunction parser.parseResponse
-    
+
     describe 'its return', () ->
       output = ""
-    
+
       before () ->
         output = parser.parseResponse(responseString)
 
       ['statusCode', 'statusMessage', 'headers', 'body'].forEach (key) ->
         it 'should have key "'+ key + '"', () ->
           assert.include Object.keys(output), key
-      
+
       describe "statusCode", () ->
         subject = ""
-        
+
         before () ->
           subject = output['statusCode']
-        
+
         it 'should contain "201"', () ->
           assert.equal subject, "201"
 
       describe "statusMessage", () ->
         subject = ""
-        
+
         before () ->
           subject = output['statusMessage']
-        
+
         it 'should contain "Created"', () ->
           assert.equal subject, "Created"
 
       describe "headers", () ->
         subject = ""
-        
+
         before () ->
           subject = output['headers']
-        
+
         it 'should be object', () ->
           assert.isObject subject
 
-        it 'should have "Content-Type" key', () -> 
+        it 'should have "Content-Type" key', () ->
           assert.include Object.keys(subject), "Content-Type"
-         
+
         it 'should have proper Content-Type value', () ->
           agentString = "application/json"
           assert.equal agentString, subject['Content-Type']
 
       describe "body", () ->
         subject = ""
-        
+
         before () ->
           subject = output['body']
 
         it 'should contain proper body string', () ->
           expectedBody = '{ "status": "created", "url": "/shopping-cart/2" }'
           assert.equal expectedBody, subject
-    
+
+  # http://www.w3.org/Protocols/rfc2616/rfc2616-sec6.html#sec6
+  describe "parseResponse(responseString) (w/ multi word status message)", () ->
+    responsePath = "/../fixtures/get/response-string-304"
+    responseString = ""
+
+    before (done) ->
+      #load fixture
+      fs.readFile __dirname + responsePath, (err, data) ->
+        done err if err
+        responseString = data.toString()
+        done()
+
+    it "is a function", () ->
+      assert.isFunction parser.parseResponse
+
+    describe 'its return', () ->
+      output = ""
+
+      before () ->
+        output = parser.parseResponse(responseString)
+
+      ['statusCode', 'statusMessage', 'headers', 'body'].forEach (key) ->
+        it 'should have key "'+ key + '"', () ->
+          assert.include Object.keys(output), key
+
+      describe "statusCode", () ->
+        subject = ""
+
+        before () ->
+          subject = output['statusCode']
+
+        it 'should contain "304"', () ->
+          assert.equal subject, "304"
+
+      describe "statusMessage", () ->
+        subject = ""
+
+        before () ->
+          subject = output['statusMessage']
+
+        it 'should contain "Not Modified"', () ->
+          assert.equal subject, "Not Modified"
+
+      describe "headers", () ->
+        subject = ""
+
+        before () ->
+          subject = output['headers']
+
+        it 'should be object', () ->
+          assert.isObject subject
+
+        it 'should have "Content-Type" key', () ->
+          assert.include Object.keys(subject), "Content-Type"
+
+        it 'should have proper Content-Type value', () ->
+          agentString = "application/json"
+          assert.equal agentString, subject['Content-Type']
+
+      describe "body", () ->
+        subject = ""
+
+        before () ->
+          subject = output['body']
+
+        it 'should contain proper body string', () ->
+          expectedBody = '{ "message": "hello world" }'
+          assert.equal expectedBody, subject

--- a/test/unit/parser-test.coffee
+++ b/test/unit/parser-test.coffee
@@ -175,9 +175,18 @@ describe "parser module", () ->
       before () ->
         output = parser.parseResponse(responseString)
 
-      ['statusCode', 'statusMessage', 'headers', 'body'].forEach (key) ->
+      ['protocolVersion', 'statusCode', 'statusMessage', 'headers', 'body'].forEach (key) ->
         it 'should have key "'+ key + '"', () ->
           assert.include Object.keys(output), key
+
+      describe "protocolVersion", () ->
+        subject = ""
+
+        before () ->
+          subject = output['protocolVersion']
+
+        it 'should contain "HTTP/1.1"', () ->
+          assert.equal subject, "HTTP/1.1"
 
       describe "statusCode", () ->
         subject = ""


### PR DESCRIPTION
Splitting HTTP status line by ' ' (space) breaks multiple words status messages (e.g. "Not Modified").
This fix uses a RegExp to split status messages in its parts: HTTP-Version, Status-Code and Reason-Phrase.