### PR TITLE
Add dependabot config

### DIFF
--- a/.dependabot/config.yml
+++ b/.dependabot/config.yml
@@ -1,0 +1,11 @@
+version: 1
+update_configs:
+  - package_manager: "javascript"
+    directory: "/"
+    update_schedule: "weekly"
+    default_labels:
+      - "dependencies"
+    commit_message:
+      prefix: "fix"
+      prefix_development: "chore"
+      include_scope: true

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,10 +1,4 @@
 language: node_js
 node_js:
-  - 0.8
-  - 0.10
-notifications:
-  email:
-    recipients:
-      - adam@apiary.io
-    on_success: change
-    on_failure: always
+  - 8
+  - 10

--- a/package.json
+++ b/package.json
@@ -18,6 +18,9 @@
     "chai": "1.7.1",
     "curl-trace-parser": ""
   },
+  "engines": {
+    "node": ">=8"
+  },
   "keywords": [
     "http",
     "message",


### PR DESCRIPTION
Explicit configuration makes things explicit 😄 We've experienced inconsistent dependabot behavior if it was left up to them to detect, so forcing what we want by an explicit config.